### PR TITLE
Fix bidirectional stream

### DIFF
--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -72,7 +72,7 @@ private:
     yarp::os::ManagedBytes monitor;
     bool closed {false};
     bool interrupting {false};
-    bool reader {false};
+    bool openedAsReader {false};
     yarp::os::Contact localAddress;
     yarp::os::Contact remoteAddress;
     std::mutex mutex;

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -34,7 +34,7 @@ bool UnixSocketCarrier::requireAck() const
 
 bool UnixSocketCarrier::isConnectionless() const
 {
-    return true;
+    return false;
 }
 
 bool UnixSocketCarrier::canEscape() const


### PR DESCRIPTION
#### `Bidirectional communication fixed`

* I managed to Fix the bidirectional communication for the unix socket. Now, for example, if used to connect to and `rpc` port via `yarp rpc` replies can be received.
* There is still one issue though: when used to connect, for example, an image port with the `yarpview` input port, yarpview does not close correctly anymore and is left hanging. This also happens, for example, if the unix socket is used as carrier for the communication between a port sending out numeric data and a port opened with `yarp read`. When trying to kill the input port by pressing `Ctrl+C`, the process just hangs there until 'Ctrl+c` are pressed a second time. Unfortunately I did not found the source of the issue. Any suggestion is more than welcome.